### PR TITLE
Alternative DATA-IF syntax

### DIFF
--- a/tempo.js
+++ b/tempo.js
@@ -221,7 +221,10 @@ var Tempo = (function (tempo) {
             for (var a = 0; a < element.attributes.length; a++) {
                 var attr = element.attributes[a];
                 // If attribute
-                if (utils.startsWith(attr.name, 'data-if-')) {
+                if (attr.name == 'data-if') {
+					this.namedTemplates[attr.value] = element;
+					nonDefault = true;
+				} else if (utils.startsWith(attr.name, 'data-if-')) {
                     var val;
                     if (attr.value === '') {
                         val = true;


### PR DESCRIPTION
We added an alternative/simple syntax for data-if
It evaluates the value of the data-if attribute under the current context.
Please, let us know if this is the right approach, or if there's anything else we could improve.

The reason we added this feature, is because under some not-yet-understood circumpstances, a mixed-case model was being compared against a lower-case text produced by the browser (our guess)

Example:

data-if-userAge="30"

was being translated (by some browsers, we guess) into:

data-if-userage="30"
