### PR TITLE
Fixed iteration bug in clearContainer

### DIFF
--- a/tempo.js
+++ b/tempo.js
@@ -63,7 +63,7 @@ var Tempo = (function (tempo) {
 
         clearContainer: function (el) {
             if (el !== null && el !== undefined && el.childNodes !== undefined) {
-                for (var i = el.childNodes.length; i >= 0; i--) {
+                for (var i = el.childNodes.length - 1; i >= 0; i--) {
                     if (el.childNodes[i] !== undefined && el.childNodes[i].getAttribute !== undefined && el.childNodes[i].getAttribute('data-template') !== null) {
                         el.childNodes[i].parentNode.removeChild(el.childNodes[i]);
                     }


### PR DESCRIPTION
Fixed iteration bug in clearContainer that caused the first iteration to index 1 past container length
