### PR TITLE
fixing splitting of filter args to preserve an empty string arg

### DIFF
--- a/tempo.js
+++ b/tempo.js
@@ -442,13 +442,13 @@ var Tempo = (function (tempo) {
                     if (args !== undefined && args !== '') {
                         var filters = utils.trim(utils.trim(args).substring(1)).split(self.filterSplitter);
                         for (var p = 0; p < filters.length; p++) {
-                            var filter = utils.trim(filters[p]);
-                            var filter_args = [];
+                            var filter = utils.trim(filters[p]), filter_args, j = filter.indexOf(' ');
                             // If there is a space, there must be arguments
-                            if (filter.indexOf(' ') > -1) {
-                                var f = filter.substring(filter.indexOf(' ')).replace(/^[ ']*|[ ']*$/g, '');
-                                filter_args = f.split(/(?:[\'"])[ ]?,[ ]?(?:[\'"])/);
-                                filter = filter.substring(0, filter.indexOf(' '));
+                            if (~j) {
+                                filter_args = filter.substr(j).replace(/(^ *['"])|(['"] *$)/g, '').split(/['"] *, *['"]/);
+                                filter = filter.substr(0, j);
+                            } else {
+                                filter_args = [];
                             }
                             val = renderer.filters[filter](val, filter_args);
                         }

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -82,7 +82,8 @@ test('trim', function () {
 test('replace', function () {
 	equal(filters.replace('foot simpson', ['foo', 'bar']), 'bart simpson', 'Replacing simple value');
 	equal(filters.replace('foo 123 bar', ['([0-9]+)', '|$1|']), 'foo |123| bar', 'Replacing value with backreference');
-	equal(filters.replace(undefined, ['([0-9]+)', '|$1|']), undefined, 'Trying to replace in undefined value');
+  equal(filters.replace('http://github.io', ['^http://', '']), 'github.io', 'Replacing with an empty string');
+  equal(filters.replace(undefined, ['([0-9]+)', '|$1|']), undefined, 'Trying to replace in undefined value');
 });
 
 test('append', function() {
@@ -136,11 +137,13 @@ var array = ['foo', 'bar'];
 
 var str = 'Sample {{ $foo }} string.';
 var str2 = 'Sample {{.}} string.';
+var str3 = 'Sample {{$foo | replace  "a+"  ,  \'\'  }} string.';
 
 test('_replaceVariables', function () {
     equal(renderer._replaceVariables(renderer, {}, item, str), 'Sample bar string.');
     equal(renderer._replaceVariables(renderer, {}, item, str2), 'Sample [object Object] string.');
     equal(renderer._replaceVariables(renderer, {}, array, str2), 'Sample foo,bar string.');
+    equal(renderer._replaceVariables(renderer, {}, item, str3), 'Sample br string.');
 });
 
 test('_replaceObjects', function () {


### PR DESCRIPTION
Without this pull request, tempo fails to execute the replace filter in:
`{{value | replace 'pattern', ''}}`
...because the regular expression used to trim the leading and trailing filter argument quotes can remove multiple quote characters, entirely eliminating the second argument.
